### PR TITLE
SCRS-11026 Added ability to remove filters applied to a search

### DIFF
--- a/app/views/helpers/templates/searchBar.scala.html
+++ b/app/views/helpers/templates/searchBar.scala.html
@@ -16,12 +16,15 @@
 
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import helpers.templates._
-@(form: Form[SicSearch], actionCall: Call)(implicit request: Request[_], messages: Messages)
+@(legend: String, form: Form[SicSearch], actionCall: Call)(implicit request: Request[_], messages: Messages)
 
 @govHelpers.form(action = actionCall) {
     <div class="search-header">
         <div class="searchfield">
             <fieldset class="search-input">
+                <legend style="display: none">
+                    @legend
+                </legend>
                 @govHelpers.input(
                     form("sicSearch"),
                     '_divClass -> "form-group",

--- a/app/views/pages/chooseactivity.scala.html
+++ b/app/views/pages/chooseactivity.scala.html
@@ -40,7 +40,7 @@
     <h2 class="heading-medium" id="page-sub-heading">@messages("page.icl.chooseactivity.subheading")</h2>
 
 
-    @searchBar(sicSearchForm, controllers.routes.ChooseActivityController.submit(journeyId, Some("invalid-search")))
+    @searchBar(messages("page.icl.chooseactivity.subheading"), sicSearchForm, controllers.routes.ChooseActivityController.submit(journeyId, Some("invalid-search")))
 
 
     @oSearchResults.map { searchResults =>

--- a/app/views/pages/chooseactivity.scala.html
+++ b/app/views/pages/chooseactivity.scala.html
@@ -82,6 +82,13 @@
                                         @Html(messages("page.icl.chooseactivity.insector", sector.name))
                                     }
                                 </td>
+                                @searchResults.currentSector.map { filterApplied =>
+                                    <td>
+                                        <a id="remove-filter" href="@controllers.routes.ChooseActivityController.clearFilter(journeyId)">
+                                            @messages("page.icl.chooseactivity.removeFilter")
+                                        </a>
+                                    </td>
+                                }
                             </tr>
                         </table>
                     </div>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,6 +6,7 @@ GET        /sign-out                                                         con
 GET        /:jId/search-standard-industry-classification-codes               controllers.ChooseActivityController.show(jId, doSearch: Option[Boolean] ?= None)
 POST       /:jId/search-standard-industry-classification-codes               controllers.ChooseActivityController.submit(jId, doSearch: Option[String] ?= None)
 GET        /:jId/filter-business-activities/:code                            controllers.ChooseActivityController.filter(jId, code)
+GET        /:jId/remove-filter                                               controllers.ChooseActivityController.clearFilter(jId)
 
 GET        /:jId/check-confirm-standard-industry-classification-codes        controllers.ConfirmationController.show(jId)
 POST       /:jId/check-confirm-standard-industry-classification-codes        controllers.ConfirmationController.submit(jId)

--- a/conf/messages
+++ b/conf/messages
@@ -29,6 +29,7 @@ page.icl.chooseactivity.heading                 = Standard Industry Classificati
 page.icl.chooseactivity.subheading              = Search for a thing that the company does
 page.icl.chooseactivity.enteredkeyword          = You searched for
 page.icl.chooseactivity.resultsfound            = results
+page.icl.chooseactivity.removeFilter            = Remove filter
 page.icl.chooseactivity.insector                = in <b class="bold">{0}</b>
 page.icl.chooseactivity.searchagain             = Please try searching again using different words
 page.icl.chooseactivity.changehidden            = Change sic code used to search

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,10 +3,10 @@ import play.core.PlayVersion
 
 private object AppDependencies {
   val compile = Seq(
-    "uk.gov.hmrc" %% "frontend-bootstrap"    % "8.20.0",
-    "uk.gov.hmrc" %% "bootstrap-play-25"     % "1.5.0",
-    "uk.gov.hmrc" %% "govuk-template"        % "5.20.0",
-    "uk.gov.hmrc" %% "play-ui"               % "7.14.0",
+    "uk.gov.hmrc" %% "frontend-bootstrap"    % "8.24.0",
+    "uk.gov.hmrc" %% "bootstrap-play-25"     % "1.7.0",
+    "uk.gov.hmrc" %% "govuk-template"        % "5.22.0",
+    "uk.gov.hmrc" %% "play-ui"               % "7.17.0",
     "uk.gov.hmrc" %% "auth-client"           % "2.6.0",
     "uk.gov.hmrc" %% "play-whitelist-filter" % "2.0.0",
     "uk.gov.hmrc" %% "play-reactivemongo"    % "6.2.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.co
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.7.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.9.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.10.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.0.0")
 

--- a/test/controllers/ChooseActivityControllerSpec.scala
+++ b/test/controllers/ChooseActivityControllerSpec.scala
@@ -305,7 +305,7 @@ class ChooseActivityControllerSpec extends UnitTestSpec with UnitTestFakeApp {
 
       when(mockJourneyService.getJourney(ArgumentMatchers.any())) thenReturn Future.successful(journeyData)
 
-      requestWithAuthorisedUser(controller.filter(journeyId, SECTOR_A), requestWithSession) {
+      requestWithAuthorisedUser(controller.clearFilter(journeyId), requestWithSession) {
         result =>
           status(result) mustBe SEE_OTHER
           redirectLocation(result) mustBe Some(routes.ChooseActivityController.show(journeyId, Some(true)).url)

--- a/test/controllers/ChooseActivityControllerSpec.scala
+++ b/test/controllers/ChooseActivityControllerSpec.scala
@@ -294,4 +294,22 @@ class ChooseActivityControllerSpec extends UnitTestSpec with UnitTestFakeApp {
       }
     }
   }
+
+  "clearFilter" should {
+    "refresh the Business Activity Lookup page" in new Setup {
+      when(mockSicSearchService.retrieveSearchResults(eqTo(sessionId))(any()))
+        .thenReturn(Future.successful(Some(searchResults)))
+
+      when(mockSicSearchService.search(any(), eqTo(query), any())(any()))
+        .thenReturn(Future.successful(1))
+
+      when(mockJourneyService.getJourney(ArgumentMatchers.any())) thenReturn Future.successful(journeyData)
+
+      requestWithAuthorisedUser(controller.filter(journeyId, SECTOR_A), requestWithSession) {
+        result =>
+          status(result) mustBe SEE_OTHER
+          redirectLocation(result) mustBe Some(routes.ChooseActivityController.show(journeyId, Some(true)).url)
+      }
+    }
+  }
 }


### PR DESCRIPTION
# SCRS-11026 - Added filter button when user has applied sector filters to their search

**New feature**

There is now an option to remove filters when a sector filter has been applied to a search. This is only displayed when a filter is presently applied.

## Checklist

* [x] I've included appropriate tests with any code I've added
See https://github.com/hmrc/industry-classification-lookup-acceptance-tests/pull/10
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
