### PR TITLE
SCRS-11745 Amended setup to have booster option, removed fuzzy option

### DIFF
--- a/app/connectors/ICLConnector.scala
+++ b/app/connectors/ICLConnector.scala
@@ -54,7 +54,11 @@ trait ICLConnector {
   def search(query: String, journeySetup: JourneySetup, sector: Option[String] = None)(implicit hc: HeaderCarrier): Future[SearchResults] = {
     implicit val reads: Reads[SearchResults] = SearchResults.readsWithQuery(query)
     val sectorFilter = sector.fold("")(s => s"&sector=$s")
-    val constructUrlParameters = s"query=$query&pageResults=${journeySetup.amountOfResults}$sectorFilter&queryType=${journeySetup.journeyType}&indexName=${journeySetup.dataSet}"
+    val constructUrlParameters = s"query=$query" +
+      s"&pageResults=${journeySetup.amountOfResults}$sectorFilter" +
+      s"&queryParser=${journeySetup.queryParser}" +
+      s"&queryBoostFirstTerm=${journeySetup.queryBooster.getOrElse(false)}" +
+      s"&indexName=${journeySetup.dataSet}"
 
     http.GET[SearchResults](s"$ICLUrl/industry-classification-lookup/search?$constructUrlParameters") recover {
       case e: HttpException =>

--- a/app/models/setup/JourneyData.scala
+++ b/app/models/setup/JourneyData.scala
@@ -37,13 +37,15 @@ object Identifiers {
 }
 
 case class JourneySetup(dataSet: String = JourneyData.ONS,
-                        journeyType: String = JourneyData.QUERY_BOOSTER,
+                        queryParser: Boolean = false,
+                        queryBooster: Option[Boolean],
                         amountOfResults: Int = 50)
 object JourneySetup {
   val mongoWrites: Writes[JourneySetup] = new Writes[JourneySetup] {
     override def writes(o: JourneySetup): JsValue = Json.obj(
       "journeySetupDetails.dataSet" -> o.dataSet,
-      "journeySetupDetails.journeyType" -> o.journeyType,
+      "journeySetupDetails.queryParser" -> o.queryParser,
+      "journeySetupDetails.queryBooster" -> o.queryBooster,
       "journeySetupDetails.amountOfResults" -> o.amountOfResults
     )
   }
@@ -54,8 +56,7 @@ object JourneyData extends TimeFormat {
   val QUERY_BUILDER = "query-builder"
   val QUERY_PARSER  = "query-parser"
   val QUERY_BOOSTER = "query-boost-first-term"
-  val FUZZY_QUERY   = "fuzzy-query"
-  val journeyNames = Seq(QUERY_PARSER, QUERY_BUILDER, QUERY_BOOSTER, FUZZY_QUERY)
+  val journeyNames = Seq(QUERY_PARSER, QUERY_BUILDER, QUERY_BOOSTER)
   //Data sets
   val HMRC_SIC_8 = "hmrc-sic8"
   val GDS        = "gds-register-sic5"
@@ -78,7 +79,7 @@ object JourneyData extends TimeFormat {
     (__ \ "identifiers").read(Identifiers(UUID.randomUUID().toString, sessionId)) and
     (__ \ "redirectUrl").read[String] and
     (__ \ "customMessages").readNullable[CustomMessages] and
-    (__ \ "journeySetupDetails").read(JourneySetup()) and
+    (__ \ "journeySetupDetails").read(JourneySetup(queryBooster = None)) and
     (__ \ "lastUpdated").read(LocalDateTime.now)
   )(JourneyData.apply _)
 }

--- a/app/views/helpers/templates/inputRadioHidden.scala.html
+++ b/app/views/helpers/templates/inputRadioHidden.scala.html
@@ -1,0 +1,82 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(field: Field, radioOptions: Seq[(String, String)], radioAdditionalInfo: Map[String, Html], args: (Symbol, Any)*)(implicit lang: play.api.i18n.Lang, messages: Messages)
+
+@import views.html.helper._
+
+@elements = @{new FieldElements(field.id, field, null, args.toMap, messages) }
+@fieldsetClass = {@elements.args.get('_groupClass).asInstanceOf[Option[String]].map(_.replace("inline", ""))@if(elements.hasErrors){ form-group-error}}
+@labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
+
+<div class="form-group @fieldsetClass">
+    <fieldset id="@field.id"
+              @if(elements.args.get('_fieldsetAttributes).isDefined) {@elements.args.get('_fieldsetAttributes)}>
+
+    @if(elements.args.get('_legend).isDefined) {
+    <legend class="visually-hidden @if(elements.args.get('_legendClass).isDefined) {@elements.args.get('_legendClass)}">
+        @elements.args.get('_legend)
+    </legend>
+    }
+
+    @if(elements.args.get('_helpText).isDefined) {<span class="error-message">@elements.args.get('_helpText)</span>}
+
+    @elements.errors.map{error => <span class="error-notification" id='@{field.id+"-error-message"}'>@Messages(error)</span>}
+
+    @radioOptions.map { case (value, label) =>
+    @defining(s"${elements.field.name}-${value.toLowerCase.replace(" ","_")}")  { inputId =>
+    <div class="multiple-choice">
+        <input
+                type="radio"
+                id="@inputId"
+                name="@elements.field.name"
+                value="@value"
+                @elements.args.get('_inputClass).map{inputClass => class="@inputClass"}
+        @if(elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
+        @field.value.filter( _ == value).map{_ => checked="checked"}/>
+        <label for="@inputId"
+               @elements.args.get('_labelClass).map{labelClass => class="@labelClass@field.value.filter( _ == value).map{_ => selected}"}>
+        @if(!labelAfter) {
+        @if(elements.args.get('_stackedLabel)) {
+        @if(label.split(" ").length < 2) {<br>@label
+        } else {
+        @for( (l, index) <- label.split(" ").zipWithIndex) {
+        @if(index != 0) {<br>}@l
+        }
+        }
+        } else { @label }
+        }
+
+        @if(labelAfter) {
+        @if(elements.args.get('_stackedLabel)) {
+        @if(label.split(" ").length < 2) {
+        <br>@Html(label)
+        } else {
+        @for( (l, index) <- label.split(" ").zipWithIndex) {
+        @if(index != 0) {<br>}@Html(l)
+        }
+        }
+        } else { @Html(label) }
+        }
+        </label>
+    </div>
+    @radioAdditionalInfo.get(value).map { additionalInfo =>
+    @additionalInfo
+    }
+    }
+    }
+    </fieldset>
+</div>

--- a/app/views/test/SetupJourneyView.scala.html
+++ b/app/views/test/SetupJourneyView.scala.html
@@ -16,10 +16,24 @@
 
 @import config.AppConfig
 @import uk.gov.hmrc.play.views.html.helpers.form
-@import helpers.templates.{inputRadioGroup, input}
+@import helpers.templates.{inputRadioGroup, inputRadioHidden, inputCheckboxGroup, input}
 @import models.setup.{JourneySetup, JourneyData}
 
 @(journeyId: String, journeyForm: Form[JourneySetup])(implicit request: Request[_], messages: Messages, appConfiguration: AppConfig)
+
+@hiddenYesContent = {
+<div class="additional-option-block panel panel-border-narrow">
+    @inputRadioGroup(
+        field = journeyForm("booster"),
+        Seq(
+            "false"   -> messages("page.test.setup-journey.radio.query-booster-no"),
+            "true"    -> messages("page.test.setup-journey.radio.query-booster")
+        ),
+        '_legendClass -> "hidden",
+        '_labelClass -> "block-label"
+    )
+</div>
+}
 
 @views.html.main_template(title = messages("page.test.setup-journey.title"), bodyClasses = None) {
 
@@ -30,16 +44,17 @@
 
     @form(action = controllers.test.routes.TestSetupController.submit(journeyId)) {
         <p>@messages("page.test.setup-journey.radio.alg.title")</p>
-        @inputRadioGroup(
-            field = journeyForm("journey"),
-            Seq(
-                JourneyData.QUERY_BUILDER   -> messages("page.test.setup-journey.radio.query-builder"),
-                JourneyData.QUERY_PARSER    -> messages("page.test.setup-journey.radio.query-parser"),
-                JourneyData.QUERY_BOOSTER   -> messages("page.test.setup-journey.radio.query-booster"),
-                JourneyData.FUZZY_QUERY     -> messages("page.test.setup-journey.radio.fuzzy-query")
+        @inputRadioHidden(
+            field = journeyForm("queryParser"),
+            radioOptions = Seq(
+                "false"   -> messages("page.test.setup-journey.radio.query-builder"),
+                "true"    -> messages("page.test.setup-journey.radio.query-parser")
             ),
-            '_legendClass -> "hidden",
-            '_labelClass -> "block-label"
+            radioAdditionalInfo = Map(
+                "false" -> hiddenYesContent
+            ),
+            '_labelClass -> "block-label",
+            '_legendClass -> "visually-hidden"
         )
         <br>
 

--- a/conf/messages
+++ b/conf/messages
@@ -55,6 +55,7 @@ page.test.setup-journey.radio.alg.title         = Select the Lucene algorithm to
 page.test.setup-journey.radio.query-builder     = Query builder
 page.test.setup-journey.radio.query-parser      = Query parser
 page.test.setup-journey.radio.query-booster     = Query boost first term
+page.test.setup-journey.radio.query-booster-no  = No query boost
 page.test.setup-journey.radio.fuzzy-query       = Fuzzy query (on zero results)
 
 page.test.setup-journey.radio.data-set.title    = Select the data set to use

--- a/it/config/WhitelistFilterISpec.scala
+++ b/it/config/WhitelistFilterISpec.scala
@@ -48,7 +48,7 @@ class WhitelistFilterISpec extends ClientSpec {
 
   val searchUri = "/sic-search/testJourneyId/search-standard-industry-classification-codes"
 
-  val journeyData = JourneyData(Identifiers("testJourneyId", "test-session-id"), "redirectUrl", None, JourneySetup(), LocalDateTime.now())
+  val journeyData = JourneyData(Identifiers("testJourneyId", "test-session-id"), "redirectUrl", None, JourneySetup(queryBooster = Some(true)), LocalDateTime.now())
 
   override implicit lazy val app: Application = new GuiceApplicationBuilder()
     .configure(testAppConfig ++ extraConfig)

--- a/it/internal/ApiControllerISpec.scala
+++ b/it/internal/ApiControllerISpec.scala
@@ -158,7 +158,7 @@ class ApiControllerISpec extends ClientSpec {
         val sicStore: SicStore = SicStore(sessionIdValue, None, Some(sicCodeChoices))
         insertSicStore(sicStore)
 
-        val journey: JourneyData = JourneyData(Identifiers(journeyId, sessionIdValue), "redirect-url", None, JourneySetup(), LocalDateTime.now())
+        val journey: JourneyData = JourneyData(Identifiers(journeyId, sessionIdValue), "redirect-url", None, JourneySetup(queryBooster = Some(true)), LocalDateTime.now())
         insertJourney(journey)
 
         assertFutureResponse(buildClient(fetchResultsUrl).withHeaders(HeaderNames.COOKIE -> sessionId).get()) { res =>
@@ -194,7 +194,7 @@ class ApiControllerISpec extends ClientSpec {
         val sessionIdValue = "test-session-id"
         val sessionId: String = getSessionCookie(sessionID = "test-session-id")
 
-        val journey: JourneyData = JourneyData(Identifiers(journeyId, sessionIdValue), "redirect-url", None, JourneySetup(), LocalDateTime.now())
+        val journey: JourneyData = JourneyData(Identifiers(journeyId, sessionIdValue), "redirect-url", None, JourneySetup(queryBooster = Some(true)), LocalDateTime.now())
         insertJourney(journey)
 
         assertFutureResponse(buildClient(fetchResultsUrl).withHeaders(HeaderNames.COOKIE -> sessionId).get()) { res =>

--- a/it/repositories/JourneyDataRepositoryISpec.scala
+++ b/it/repositories/JourneyDataRepositoryISpec.scala
@@ -60,7 +60,7 @@ class JourneyDataRepositoryISpec extends PlaySpec with WithFakeApplication with 
         lead = Some("testMessage2")
       ))
     )),
-    journeySetupDetails = JourneySetup(),
+    journeySetupDetails = JourneySetup(queryBooster = Some(true)),
     lastUpdated = now
   )
 
@@ -72,7 +72,7 @@ class JourneyDataRepositoryISpec extends PlaySpec with WithFakeApplication with 
       ),
       redirectUrl = "test/url",
       customMessages = None,
-      journeySetupDetails = JourneySetup(),
+      journeySetupDetails = JourneySetup(queryBooster = Some(true)),
       lastUpdated = now
     )
     "successfully insert JourneyData into collection" in new Setup {
@@ -101,7 +101,7 @@ class JourneyDataRepositoryISpec extends PlaySpec with WithFakeApplication with 
   }
   "updateJourneySetup" should {
     "updateJourneySetup model within JourneyData Model successfully" in new Setup {
-      val updatedJourneySetup = JourneySetup("foo","bar",10)
+      val updatedJourneySetup = JourneySetup("foo",true,None,10)
       await(repository.upsertJourney(journeyData)) mustBe journeyData
       count mustBe 1
       await(repository.updateJourneySetup(journeyData.identifiers, updatedJourneySetup)) mustBe updatedJourneySetup
@@ -109,7 +109,7 @@ class JourneyDataRepositoryISpec extends PlaySpec with WithFakeApplication with 
       await(repository.retrieveJourneyData(journeyData.identifiers)) mustBe journeyData.copy(journeySetupDetails = updatedJourneySetup)
     }
     "fail to update journeySetup and throw exception if no document exists" in new Setup {
-      val validJourneySetup = JourneySetup("foo","bar",10)
+      val validJourneySetup = JourneySetup("foo",true,None,10)
       count mustBe 0
       intercept[Exception](await(repository.updateJourneySetup(journeyData.identifiers, validJourneySetup)))
       count mustBe 0
@@ -119,7 +119,7 @@ class JourneyDataRepositoryISpec extends PlaySpec with WithFakeApplication with 
   "retrieveJourneyData" should {
     "successfully return a JourneyData" in new Setup {
       insert(journeyData)
-      await(repository.retrieveJourneyData(journeyData.identifiers)).journeySetupDetails mustBe JourneySetup()
+      await(repository.retrieveJourneyData(journeyData.identifiers)).journeySetupDetails mustBe JourneySetup(queryBooster = Some(true))
     }
 
     "throw a RuntimeException when the journey does not exist in the repo" in new Setup {

--- a/it/repositories/SicStoreRepoISpec.scala
+++ b/it/repositories/SicStoreRepoISpec.scala
@@ -62,7 +62,7 @@ class SicStoreRepoISpec extends UnitSpec with MongoSpecSupport with WithFakeAppl
   val sicStoreNoChoices = SicStore(sessionId, Some(searchResults), None, dateTime)
   val sicStore1Choice = SicStore(sessionId, Some(searchResults), Some(List(sicCodeGroup)), dateTime)
   val sicStore2Choices = SicStore(sessionId, Some(searchResults2), Some(List(sicCodeGroup, sicCodeGroup2)), dateTime)
-  val journeySetup     = JourneySetup(dataSet,journey,50)
+  val journeySetup     = JourneySetup(dataSet,true,None,50)
   "retrieveSicStore" should {
 
     "return a sic store when it is present" in new Setup {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,8 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "play-ui"               % "7.17.0",
     "uk.gov.hmrc" %% "auth-client"           % "2.6.0",
     "uk.gov.hmrc" %% "play-whitelist-filter" % "2.0.0",
-    "uk.gov.hmrc" %% "play-reactivemongo"    % "6.2.0"
+    "uk.gov.hmrc" %% "play-reactivemongo"    % "6.2.0",
+    "uk.gov.hmrc" %% "play-conditional-form-mapping" % "0.2.0"
   )
 
   def test(scope: String = "test,it") = Seq(

--- a/test/connectors/ICLConnectorSpec.scala
+++ b/test/connectors/ICLConnectorSpec.scala
@@ -81,9 +81,18 @@ class ICLConnectorSpec extends UnitTestSpec {
     val zeroResults = SearchResults(query, 0, List(), List())
     val searchResults = SearchResults(query, 1, List(SicCode("12345", "some description")), List(Sector("A", "Example of a business sector", 1)))
     val sector = "B"
-    val journeySetup = JourneySetup(dataSet = "foo",journeyType = "bar", amountOfResults = 5)
-    val searchUrl = s"$iCLUrl/industry-classification-lookup/search?query=$query&pageResults=${journeySetup.amountOfResults}&queryType=${journeySetup.journeyType}&indexName=${journeySetup.dataSet}"
-    val searchSectorUrl = s"$iCLUrl/industry-classification-lookup/search?query=$query&pageResults=${journeySetup.amountOfResults}&sector=$sector&queryType=${journeySetup.journeyType}&indexName=${journeySetup.dataSet}"
+    val journeySetup = JourneySetup(dataSet = "foo", queryBooster = None, amountOfResults = 5)
+    val searchUrl = s"$iCLUrl/industry-classification-lookup/search?query=$query" +
+      s"&pageResults=${journeySetup.amountOfResults}" +
+      s"&queryParser=${journeySetup.queryParser}" +
+      s"&queryBoostFirstTerm=${journeySetup.queryBooster.getOrElse(false)}" +
+      s"&indexName=${journeySetup.dataSet}"
+    val searchSectorUrl = s"$iCLUrl/industry-classification-lookup/search?query=$query" +
+      s"&pageResults=${journeySetup.amountOfResults}" +
+      s"&sector=$sector" +
+      s"&queryParser=${journeySetup.queryParser}" +
+      s"&queryBoostFirstTerm=${journeySetup.queryBooster.getOrElse(false)}" +
+      s"&indexName=${journeySetup.dataSet}"
 
     "return a SearchResults case class when one is returned from ICL" in new Setup {
       mockHttpGet[SearchResults](searchUrl).thenReturn(Future.successful(searchResults))

--- a/test/controllers/ChooseActivityControllerSpec.scala
+++ b/test/controllers/ChooseActivityControllerSpec.scala
@@ -57,7 +57,7 @@ class ChooseActivityControllerSpec extends UnitTestSpec with UnitTestFakeApp {
   val sessionId = "session-12345"
   val identifiers = Identifiers(journeyId, sessionId)
 
-  val journeyData = JourneyData(identifiers, "redirectUrl", None, JourneySetup(), LocalDateTime.now())
+  val journeyData = JourneyData(identifiers, "redirectUrl", None, JourneySetup(queryBooster = None), LocalDateTime.now())
 
   val SECTOR_A = "A"
   val query = "testQuery"

--- a/test/controllers/ConfirmationControllerSpec.scala
+++ b/test/controllers/ConfirmationControllerSpec.scala
@@ -50,7 +50,7 @@ class ConfirmationControllerSpec extends UnitTestSpec with UnitTestFakeApp {
   val journeyId = "testJourneyId"
   val sessionId = "session-12345"
   val identifiers = Identifiers(journeyId, sessionId)
-  val journeyData = JourneyData(identifiers, "redirectUrl", None, JourneySetup(), LocalDateTime.now())
+  val journeyData = JourneyData(identifiers, "redirectUrl", None, JourneySetup(queryBooster = None), LocalDateTime.now())
 
   val requestWithSessionId: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSessionId(sessionId)
 

--- a/test/controllers/RemoveSicCodeControllerSpec.scala
+++ b/test/controllers/RemoveSicCodeControllerSpec.scala
@@ -49,7 +49,7 @@ class RemoveSicCodeControllerSpec extends UnitTestSpec with UnitTestFakeApp {
   val journeyId = "testJourneyId"
   val sessionId = "session-12345"
   val identifiers = Identifiers(journeyId, sessionId)
-  val journeyData = JourneyData(identifiers, "redirectUrl", None, JourneySetup(), LocalDateTime.now())
+  val journeyData = JourneyData(identifiers, "redirectUrl", None, JourneySetup(queryBooster = None), LocalDateTime.now())
 
   val requestWithSessionId: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSessionId(sessionId)
   def formRequestWithSessionId(answer: String): FakeRequest[AnyContentAsFormUrlEncoded] = requestWithSessionId.withFormUrlEncodedBody("removeCode" -> answer)

--- a/test/controllers/internal/ApiControllerSpec.scala
+++ b/test/controllers/internal/ApiControllerSpec.scala
@@ -119,7 +119,7 @@ class ApiControllerSpec extends UnitTestSpec {
 
     val journeyId = "testJourneyId"
     val sessionId = "testSessionId"
-    val journeyData = JourneyData(Identifiers(journeyId, sessionId), "redirectUrl", None, JourneySetup(), LocalDateTime.now())
+    val journeyData = JourneyData(Identifiers(journeyId, sessionId), "redirectUrl", None, JourneySetup(queryBooster = None), LocalDateTime.now())
 
     "return 200 with json" when {
       "the journey exists and there have been sic codes selected" in new Setup {

--- a/test/controllers/test/TestSetupControllerSpec.scala
+++ b/test/controllers/test/TestSetupControllerSpec.scala
@@ -55,11 +55,11 @@ class TestSetupControllerSpec extends UnitTestSpec with UnitTestFakeApp {
   val journeyId = "testJourneyId"
   val sessionId = "session-12345"
   val identifiers = Identifiers(journeyId, sessionId)
-  val journeyData = JourneyData(identifiers, "redirectUrl", None, JourneySetup(), LocalDateTime.now())
+  val journeyData = JourneyData(identifiers, "redirectUrl", None, JourneySetup(queryBooster = None), LocalDateTime.now())
 
   val journeyName: String = JourneyData.QUERY_BUILDER
   val dataSet: String     = JourneyData.HMRC_SIC_8
-  val journeySetup = JourneySetup("foo", "bar", 1)
+  val journeySetup = JourneySetup("foo", queryParser = false, queryBooster = None, 1)
 
   val sicStore = SicStore(
     sessionId,
@@ -104,7 +104,7 @@ class TestSetupControllerSpec extends UnitTestSpec with UnitTestFakeApp {
     s"return a 303 and redirect to ${controllers.routes.ChooseActivityController.show(journeyId)} when a journey is initialised" in new Setup {
 
       val request: FakeRequest[AnyContentAsFormUrlEncoded] = requestWithSessionId.withFormUrlEncodedBody(
-        "journey" -> journeyName,
+        "queryParser" -> "false",
         "dataSet" -> dataSet,
         "amountOfResults" -> "5"
       )

--- a/test/models/JourneyDataSpec.scala
+++ b/test/models/JourneyDataSpec.scala
@@ -97,15 +97,15 @@ class JourneyDataSpec extends PlaySpec {
         result.journeySetupDetails.dataSet mustBe "ons-supplement-sic5"
         result.journeySetupDetails.dataSet must not be "testSet"
 
-        result.journeySetupDetails.journeyType mustBe "query-boost-first-term"
-        result.journeySetupDetails.journeyType must not be "testType"
+        result.journeySetupDetails.queryParser mustBe false
+        result.journeySetupDetails.queryParser must not be "testType"
 
       }
     }
   }
   "journeySetup mongoWrites" should {
     "produce valid json" in {
-      val journeySetup = JourneySetup("foo","bar",5)
+      val journeySetup = JourneySetup("foo",queryParser = false,None,5)
       val expectedJson = Json.parse(
         """
           |{

--- a/test/services/JourneySetupServiceSpec.scala
+++ b/test/services/JourneySetupServiceSpec.scala
@@ -40,13 +40,13 @@ class JourneySetupServiceSpec extends UnitTestSpec with MockJourneyDataRepo {
     sessionId = "testSessionId"
   )
 
-  val journeyData = JourneyData(identifier, "/test/uri", None, JourneySetup(), now)
+  val journeyData = JourneyData(identifier, "/test/uri", None, JourneySetup(queryBooster = None), now)
 
   val testJourneyData = JourneyData(
     identifiers          = identifier,
     redirectUrl         = "/test/uri",
     customMessages      = None,
-    journeySetupDetails = JourneySetup(),
+    journeySetupDetails = JourneySetup(queryBooster = None),
     lastUpdated         = now
   )
 
@@ -74,7 +74,7 @@ class JourneySetupServiceSpec extends UnitTestSpec with MockJourneyDataRepo {
     }
   }
   "updateJourneyWithJourneySetup" should {
-    val journeySetup = JourneySetup("foo","bar",5)
+    val journeySetup = JourneySetup("foo",queryParser = false,None,5)
     "return updated Journey Setup" in new Setup {
       when(mockJourneyDataRepo.updateJourneySetup(any(),any())).thenReturn(Future.successful(journeySetup))
       await(testService.updateJourneyWithJourneySetup(journeyData.identifiers,journeySetup)) mustBe journeySetup

--- a/test/services/SicSearchServiceSpec.scala
+++ b/test/services/SicSearchServiceSpec.scala
@@ -60,7 +60,7 @@ class SicSearchServiceSpec extends UnitTestSpec {
     identifiers          = identifier,
     redirectUrl         = "/test/uri",
     customMessages      = None,
-    journeySetupDetails = JourneySetup(),
+    journeySetupDetails = JourneySetup(queryBooster = None),
     lastUpdated         = LocalDateTime.now
   )
 


### PR DESCRIPTION
# SCRS-11745 Amended setup to have booster option, removed fuzzy option

**New feature**

The test setup has been amended to have an option to boost the first term of a query. All queries are now fuzzy on the first no match, so the option for this is no longer here.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
