### PR TITLE
SCRS-11338 added in replace n.e.c with not elsewhere classified, uplifted deps non breaking

### DIFF
--- a/app/controllers/internal/ApiController.scala
+++ b/app/controllers/internal/ApiController.scala
@@ -47,7 +47,7 @@ trait ApiController extends BasicController with JourneyManager {
   def fetchResults(journeyId: String): Action[AnyContent] = Action.async { implicit request =>
     withSessionId { sessionId =>
       hasJourney(Identifiers(journeyId, sessionId)) { _ =>
-        sicSearchService.retrieveChoices(journeyId) map {
+        sicSearchService.retrieveChoicesForApi(journeyId) map {
           case Some(choices) => Ok(Json.obj("sicCodes" -> Json.toJson(choices)))
           case None => NotFound
         }

--- a/app/controllers/test/TestSetupController.scala
+++ b/app/controllers/test/TestSetupController.scala
@@ -114,7 +114,7 @@ trait TestSetupController extends ICLController with JourneyManager {
       userAuthorised() {
         withSessionId { sessionId =>
           hasJourney(Identifiers(journeyId, sessionId)) { _ =>
-            sicSearchService.retrieveChoices(journeyId) map { choices =>
+            sicSearchService.retrieveChoicesForApi(journeyId) map { choices =>
               Ok("End of Journey" + Json.prettyPrint(Json.toJson(choices)))
             }
           }

--- a/app/services/SicSearchService.scala
+++ b/app/services/SicSearchService.scala
@@ -46,10 +46,22 @@ trait SicSearchService {
   }
 
   def retrieveSearchResults(journeyId: String)(implicit ec: ExecutionContext): Future[Option[SearchResults]] = {
-    sicStoreRepository.retrieveSicStore(journeyId).map(_.flatMap(_.searchResults))
+    sicStoreRepository.retrieveSicStore(journeyId).map(_.flatMap(
+      _.searchResults.map(sResults => sResults.copy(
+        results = sResults.results.map(sicCode =>
+          sicCode.copy(description = necReplacement(sicCode.description)))))))
   }
 
+  private[services] def necReplacement(desc: String): String = desc.replace("n.e.c", "not elsewhere classified")
+
   def retrieveChoices(journeyId: String)(implicit ec: ExecutionContext): Future[Option[List[SicCodeChoice]]] = {
+    sicStoreRepository.retrieveSicStore(journeyId).map(_.flatMap{ sicStore =>
+      sicStore.choices.map(_.map(
+        sicChoice => sicChoice.copy(desc = necReplacement(sicChoice.desc))))
+    })
+  }
+
+  def retrieveChoicesForApi(journeyId: String)(implicit ec: ExecutionContext): Future[Option[List[SicCodeChoice]]] = {
     sicStoreRepository.retrieveSicStore(journeyId).map(_.flatMap(_.choices))
   }
 

--- a/it/internal/ApiControllerISpec.scala
+++ b/it/internal/ApiControllerISpec.scala
@@ -219,13 +219,13 @@ class ApiControllerISpec extends ClientSpec {
 
   "/internal/journeyID/fetch-results" must {
     "return an OK" when {
-      "the journey exists and there are selected sic codes" in new Setup {
+      "the journey exists and there are selected sic codes and does not replace n.e.c" in new Setup {
         setupUnauthorised()
 
         val sessionIdValue = "test-session-id"
         val sessionId: String = getSessionCookie(sessionID = "test-session-id")
 
-        val sicCodeChoices = List(SicCodeChoice(SicCode("12345", "test description"), Nil))
+        val sicCodeChoices = List(SicCodeChoice(SicCode("12345", "test description n.e.c"), Nil))
         val sicStore: SicStore = SicStore(journeyId, None, Some(sicCodeChoices))
         insertSicStore(sicStore)
 

--- a/it/repositories/SicStoreRepoISpec.scala
+++ b/it/repositories/SicStoreRepoISpec.scala
@@ -137,9 +137,9 @@ class SicStoreRepoISpec extends UnitSpec with MongoSpecSupport with WithFakeAppl
       fetchedDocument.lastUpdated isAfter sicStore1Choice.lastUpdated shouldBe true
     }
 
-    "insert a new sic code choice into a choices list with another choice already there" in new Setup {
+    "insert a new sic code choice into a choices list with another choice already there, with the name n.e.c which isnt replaced" in new Setup {
 
-      val sicCodeToAdd = SicCode("67891", "some description")
+      val sicCodeToAdd = SicCode("67891", "some description n.e.c")
 
       val searchResults = SearchResults("testQuery", 1, List(sicCodeToAdd), List(Sector("A", "Fake", 1)))
       val sicStoreWithExistingChoice = SicStore(journeyId, Some(searchResults), Some(List(sicCodeGroup)), dateTime)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,18 +3,18 @@ import play.core.PlayVersion
 
 private object AppDependencies {
   val compile = Seq(
-    "uk.gov.hmrc" %% "frontend-bootstrap"    % "10.3.0",
-    "uk.gov.hmrc" %% "bootstrap-play-25"     % "3.2.0",
+    "uk.gov.hmrc" %% "frontend-bootstrap"    % "10.7.0",
+    "uk.gov.hmrc" %% "bootstrap-play-25"     % "3.13.0",
     "uk.gov.hmrc" %% "govuk-template"        % "5.22.0",
     "uk.gov.hmrc" %% "play-ui"               % "7.22.0",
-    "uk.gov.hmrc" %% "auth-client"           % "2.6.0",
+    "uk.gov.hmrc" %% "auth-client"           % "2.16.0-play-25",
     "uk.gov.hmrc" %% "play-whitelist-filter" % "2.0.0",
     "uk.gov.hmrc" %% "play-reactivemongo"    % "6.2.0",
     "uk.gov.hmrc" %% "play-conditional-form-mapping" % "0.2.0"
   )
 
   def test(scope: String = "test,it") = Seq(
-    "uk.gov.hmrc"             %% "hmrctest"                     % "3.0.0"             % scope,
+    "uk.gov.hmrc"             %% "hmrctest"                     % "3.2.0"             % scope,
     "org.scalatestplus.play"  %% "scalatestplus-play"           % "2.0.0"             % scope,
     "com.github.tomakehurst"  %  "wiremock"                     % "2.11.0"            % scope,
     "org.jsoup"               %  "jsoup"                        % "1.11.1"            % scope,

--- a/test/controllers/internal/ApiControllerSpec.scala
+++ b/test/controllers/internal/ApiControllerSpec.scala
@@ -160,7 +160,40 @@ class ApiControllerSpec extends UnitTestSpec {
           .withSessionId(sessionId)
 
         when(mockJourneyService.getJourney(any())) thenReturn Future.successful(journeyData)
-        when(mockSicSearchService.retrieveChoices(any())(any())) thenReturn Future.successful(Some(sicCodeChoices))
+        when(mockSicSearchService.retrieveChoicesForApi(any())(any())) thenReturn Future.successful(Some(sicCodeChoices))
+
+        val result: Future[Result] = controller.fetchResults(journeyId)(fakeRequest)
+        status(result) mustBe OK
+        contentAsJson(result) mustBe sicCodeChoicesJson
+      }
+      "the journey exists and there have been sic codes selected with n.e.c in the description which is NOT replaced" in new Setup {
+
+        val sicCode = SicCode("12345", "test description n.e.c")
+        val sicCodeChoice = SicCodeChoice(sicCode, List("123", "456", "789"))
+        val sicCodeChoices = List(sicCodeChoice)
+
+        val sicCodeChoicesJson: JsValue = Json.parse(
+          """
+            |{
+            |  "sicCodes":[
+            |     {
+            |       "code":"12345",
+            |       "desc":"test description n.e.c",
+            |       "indexes":[
+            |         "123",
+            |         "456",
+            |         "789"
+            |       ]
+            |     }
+            |  ]
+            |}
+          """.stripMargin)
+
+        val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+          .withSessionId(sessionId)
+
+        when(mockJourneyService.getJourney(any())) thenReturn Future.successful(journeyData)
+        when(mockSicSearchService.retrieveChoicesForApi(any())(any())) thenReturn Future.successful(Some(sicCodeChoices))
 
         val result: Future[Result] = controller.fetchResults(journeyId)(fakeRequest)
         status(result) mustBe OK
@@ -192,7 +225,7 @@ class ApiControllerSpec extends UnitTestSpec {
           .withSessionId(sessionId)
 
         when(mockJourneyService.getJourney(any())) thenReturn Future.successful(journeyData)
-        when(mockSicSearchService.retrieveChoices(any())(any())) thenReturn Future.successful(None)
+        when(mockSicSearchService.retrieveChoicesForApi(any())(any())) thenReturn Future.successful(None)
 
         val result: Future[Result] = controller.fetchResults(journeyId)(fakeRequest)
         status(result) mustBe NOT_FOUND

--- a/test/controllers/test/TestSetupControllerSpec.scala
+++ b/test/controllers/test/TestSetupControllerSpec.scala
@@ -141,7 +141,7 @@ class TestSetupControllerSpec extends UnitTestSpec with MockAppConfig with MockM
 
       when(mockJourneyService.getJourney(any())) thenReturn Future.successful(journeyData)
 
-      when(mockSicSearchService.retrieveChoices(any())(any()))
+      when(mockSicSearchService.retrieveChoicesForApi(any())(any()))
         .thenReturn(Future.successful(sicCodeChoices))
 
       AuthHelpers.showWithAuthorisedUser(controller.endOfJourney(journeyId), requestWithSessionId) { result =>


### PR DESCRIPTION
added in replace for n.e.c codes only on show, not on save. end of journey spits out codes as n.e.c
## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
