### PR TITLE
SAR-10398 | Check for lang cookie and use correct custom messages

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -28,9 +28,9 @@ class AppConfig @Inject()(configuration: ServicesConfig) extends FeatureSwitchin
 
   lazy val baseUrl = {
     val localFrontendService = "microservice.services.industry-classification-lookup-frontend"
-    val host = configuration.getString(s"$localFrontendService.internal.host")
-    val port = configuration.getString(s"$localFrontendService.internal.port")
-    val protocol = configuration.getString(s"$localFrontendService.internal.protocol")
+    val host = configuration.getString(s"$localFrontendService.host")
+    val port = configuration.getString(s"$localFrontendService.port")
+    val protocol = configuration.getString(s"$localFrontendService.protocol")
 
     s"$protocol://$host:$port"
   }

--- a/app/models/setup/messages/CustomMessages.scala
+++ b/app/models/setup/messages/CustomMessages.scala
@@ -18,7 +18,7 @@ package models.setup.messages
 
 import play.api.libs.json.{Format, Json}
 
-case class CustomMessages(summary: Option[Summary])
+case class CustomMessages(summary: Option[Summary], summaryCy: Option[Summary])
 
 object CustomMessages {
   implicit val format: Format[CustomMessages] = Json.format[CustomMessages]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -133,11 +133,9 @@ microservice {
         url = "http://localhost:9514"
     }
     industry-classification-lookup-frontend {
-      internal {
         host = "localhost"
         port = "9874"
         protocol = "http"
-      }
     }
   }
 }

--- a/conf/test.routes
+++ b/conf/test.routes
@@ -9,4 +9,5 @@ GET        /feature-switches                             featureswitch.frontend.
 POST       /feature-switches                             featureswitch.frontend.controllers.FeatureSwitchFrontendController.submit
 
 GET        /api/feature-switches                         featureswitch.api.controllers.FeatureSwitchApiController.getFeatureSwitches
++ nocsrf
 POST       /api/feature-switches                         featureswitch.api.controllers.FeatureSwitchApiController.updateFeatureSwitches

--- a/it/internal/ApiControllerISpec.scala
+++ b/it/internal/ApiControllerISpec.scala
@@ -126,6 +126,11 @@ class ApiControllerISpec extends ClientSpec {
             |         "heading": "Some heading",
             |         "lead": "Some lead",
             |         "hint": "Some hint"
+            |       },
+            |       "summaryCy": {
+            |         "heading": "Welsh heading",
+            |         "lead": "Welsh lead",
+            |         "hint": "Welsh hint"
             |       }
             |     },
             |     "sicCodes": ["12345", "67890"]
@@ -156,7 +161,10 @@ class ApiControllerISpec extends ClientSpec {
           data.journeySetupDetails.queryParser mustBe None
           data.journeySetupDetails.queryBooster mustBe Some(true)
           data.journeySetupDetails.amountOfResults mustBe 200
-          data.journeySetupDetails.customMessages mustBe Some(CustomMessages(Some(Summary(heading = Some("Some heading"), lead = Some("Some lead"), hint = Some("Some hint")))))
+          data.journeySetupDetails.customMessages mustBe Some(CustomMessages(
+            Some(Summary(heading = Some("Some heading"), lead = Some("Some lead"), hint = Some("Some hint"))),
+            Some(Summary(heading = Some("Welsh heading"), lead = Some("Welsh lead"), hint = Some("Welsh hint")))
+          ))
           data.journeySetupDetails.sicCodes mustBe Seq("12345", "67890")
           await(sicStoreRepo.count) mustBe 1
         }

--- a/it/repositories/JourneyDataRepositoryISpec.scala
+++ b/it/repositories/JourneyDataRepositoryISpec.scala
@@ -54,7 +54,8 @@ class JourneyDataRepositoryISpec extends PlaySpec with Awaiting with BeforeAndAf
       heading = Some("testMessage1"),
       lead = Some("testMessage2"),
       hint = Some("testHint")
-    ))
+    )),
+    summaryCy = None
   )
 
   val journeyData = JourneyData(

--- a/test/models/JourneyDataSpec.scala
+++ b/test/models/JourneyDataSpec.scala
@@ -72,7 +72,8 @@ class JourneyDataSpec extends PlaySpec {
 
         result.redirectUrl mustBe "/test/uri"
         result.journeySetupDetails.customMessages mustBe Some(CustomMessages(
-          summary = Some(Summary(heading = Some("testMessage"), lead = Some("testMessage"), hint = None))
+          summary = Some(Summary(heading = Some("testMessage"), lead = Some("testMessage"), hint = None)),
+          summaryCy = None
         ))
       }
 
@@ -150,7 +151,10 @@ class JourneyDataSpec extends PlaySpec {
         queryParser = Some(true),
         queryBooster = Some(true),
         amountOfResults = 200,
-        customMessages = Some(CustomMessages(summary = Some(Summary(heading = Some("heading text"), lead = Some("lead text"), hint = Some("hint text"))))),
+        customMessages = Some(CustomMessages(
+          summary = Some(Summary(heading = Some("heading text"), lead = Some("lead text"), hint = Some("hint text"))),
+          summaryCy = None
+        )),
         sicCodes = Seq("12345", "67890")
       )
       val expectedJson = Json.parse(


### PR DESCRIPTION
[SAR-10398](https://jira.tools.tax.service.gov.uk/browse/SAR-10398)

**New feature**

- Update models to reflect both english & welsh content coming from VRS-FE for SICCodes
- Update view to toggle between en/cy custom messages based on language cookie set and if `WelshLanguage` FS enabled

## Checklist

* [X] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
