### PR TITLE
SAR-10768 | Add support for welsh language search

### DIFF
--- a/app/connectors/ICLConnector.scala
+++ b/app/connectors/ICLConnector.scala
@@ -44,14 +44,15 @@ class ICLConnector @Inject()(appConfig: AppConfig, http: HttpClient) extends Log
     }
   }
 
-  def search(query: String, journeySetup: JourneySetup, sector: Option[String] = None)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[SearchResults] = {
+  def search(query: String, journeySetup: JourneySetup, sector: Option[String] = None, lang: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[SearchResults] = {
     implicit val reads: Reads[SearchResults] = SearchResults.readsWithQuery(query)
     val sectorFilter = sector.fold("")(s => s"&sector=$s")
     val constructUrlParameters = s"query=$query" +
       s"&pageResults=${journeySetup.amountOfResults}$sectorFilter" +
       s"&queryParser=${journeySetup.queryParser.getOrElse(false)}" +
       s"&queryBoostFirstTerm=${journeySetup.queryBooster.getOrElse(false)}" +
-      s"&indexName=${journeySetup.dataSet}"
+      s"&indexName=${journeySetup.dataSet}" +
+      s"&lang=$lang"
 
     http.GET[SearchResults](s"$ICLUrl/industry-classification-lookup/search?$constructUrlParameters") recover {
       case e: HttpException =>

--- a/app/controllers/ICLController.scala
+++ b/app/controllers/ICLController.scala
@@ -19,7 +19,7 @@ package controllers
 import auth.SicSearchExternalURLs
 import config.Logging
 import controllers.action.ICLLanguageSupport
-import featureswitch.core.config.FeatureSwitching
+import featureswitch.core.config.{FeatureSwitching, WelshLanguage}
 import models.SicCodeChoice
 import models.setup.{Identifiers, JourneyData}
 import play.api.libs.json._
@@ -100,6 +100,13 @@ abstract class ICLController @Inject()(mcc: MessagesControllerComponents
         case listOfChoices => f(listOfChoices)
       }
       case None => Future.successful(Redirect(controllers.routes.ChooseActivityController.show(identifiers.journeyId)))
+    }
+  }
+
+  private[controllers] def getLang(implicit request: Request[_]) = {
+    request.cookies.get(messagesApi.langCookieName) match {
+      case Some(langCookie) if isEnabled(WelshLanguage) => langCookie.value
+      case _ => "en"
     }
   }
 }

--- a/app/controllers/RemoveSicCodeController.scala
+++ b/app/controllers/RemoveSicCodeController.scala
@@ -50,7 +50,7 @@ class RemoveSicCodeController @Inject()(mcc: MessagesControllerComponents,
         withJourney(journeyId) { journey =>
           withCurrentUsersChoices(journey.identifiers) { codes =>
             withSicCodeChoice(journeyId, codes, sicCode) { code =>
-              Future.successful(Ok(view(journeyId, confirmationForm(code.desc), code)))
+              Future.successful(Ok(view(journeyId, confirmationForm(code.getDescription), code)))
             }
           }
         }
@@ -63,7 +63,7 @@ class RemoveSicCodeController @Inject()(mcc: MessagesControllerComponents,
         withJourney(journeyId) { journeyData =>
           withCurrentUsersChoices(journeyData.identifiers) { codes =>
             withSicCodeChoice(journeyId, codes, sicCode) { code =>
-              confirmationForm(code.desc).bindFromRequest().fold(
+              confirmationForm(code.getDescription).bindFromRequest().fold(
                 errors => Future.successful(BadRequest(view(journeyId, errors, code))),
                 {
                   case "yes" => sicSearchService.removeChoice(journeyData.identifiers.journeyId, sicCode) map { _ =>

--- a/app/controllers/internal/ApiController.scala
+++ b/app/controllers/internal/ApiController.scala
@@ -40,7 +40,7 @@ class ApiController @Inject()(mcc: MessagesControllerComponents,
     withSessionId { sessionId =>
       withJsBody[JourneyData](JourneyData.initialRequestReads(sessionId)) { journeyData =>
         implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
-        journeyService.initialiseJourney(journeyData).map(Ok(_))
+        journeyService.initialiseJourney(journeyData, getLang).map(Ok(_))
       }
     }
   }

--- a/app/controllers/test/TestSetupController.scala
+++ b/app/controllers/test/TestSetupController.scala
@@ -98,7 +98,7 @@ class TestSetupController @Inject()(mcc: MessagesControllerComponents,
             journeySetupDetails = JourneySetup(),
             lastUpdated = LocalDateTime.now()
           )
-          journeyService.initialiseJourney(journeyData).map(_ => Redirect(controllers.test.routes.TestSetupController.show(journeyId)))
+          journeyService.initialiseJourney(journeyData, getLang).map(_ => Redirect(controllers.test.routes.TestSetupController.show(journeyId)))
         }
       }
   }

--- a/app/models/SicCodeChoice.scala
+++ b/app/models/SicCodeChoice.scala
@@ -17,16 +17,35 @@
 package models
 
 
-import play.api.libs.json.Json
+import config.AppConfig
+import featureswitch.core.config.WelshLanguage
+import play.api.i18n.Messages
+import play.api.libs.json.{Json, OFormat}
 
-case class SicCodeChoice(code: String, desc: String, indexes: List[String])
+case class SicCodeChoice(
+                          code: String,
+                          desc: String,
+                          descCy: String = "",
+                          indexes: List[String],
+                          indexesCy: List[String] = List.empty[String]
+                        ) {
+  def getDescription(implicit messages: Messages, appConfig: AppConfig): String = messages.lang.code match {
+    case "cy" if appConfig.isEnabled(WelshLanguage) => descCy
+    case _ => desc
+  }
+
+  def getIndexes(implicit messages: Messages, appConfig: AppConfig): List[String] = messages.lang.code match {
+    case "cy" if appConfig.isEnabled(WelshLanguage) => indexesCy
+    case _ => indexes
+  }
+}
 
 object SicCodeChoice {
-  implicit val format = Json.format[SicCodeChoice]
+  implicit val format: OFormat[SicCodeChoice] = Json.format[SicCodeChoice]
 
-  def apply(sicCode: SicCode, indexes: List[String]): SicCodeChoice =
-    new SicCodeChoice(sicCode.sicCode, sicCode.description, indexes)
+  def apply(sicCode: SicCode, indexes: List[String], indexesCy: List[String]): SicCodeChoice =
+    new SicCodeChoice(sicCode.sicCode, sicCode.description, sicCode.descriptionCy, indexes, indexesCy)
 
   def apply(sicCode: SicCode): SicCodeChoice =
-    new SicCodeChoice(sicCode.sicCode, sicCode.description, Nil)
+    new SicCodeChoice(sicCode.sicCode, sicCode.description, sicCode.descriptionCy, Nil)
 }

--- a/app/models/SicStore.scala
+++ b/app/models/SicStore.scala
@@ -30,7 +30,14 @@ case class SicStore(journeyId: String,
                     lastUpdated: DateTime = DateTime.now(DateTimeZone.UTC))
 
 case class SicCode(sicCode: String,
-                   description: String)
+                   description: String,
+                   descriptionCy: String = "") {
+
+  def getDescription(implicit  messages: Messages, appConfig: AppConfig): String = messages.lang.code match {
+    case "cy" if appConfig.isEnabled(WelshLanguage) => descriptionCy
+    case _ => description
+  }
+}
 
 case class SearchResults(query: String,
                          numFound: Int,
@@ -62,7 +69,8 @@ object SicStore {
 object SicCode {
   implicit val format: Format[SicCode] = (
     (__ \ "code").format[String] and
-    (__ \ "desc").format[String]
+    (__ \ "desc").format[String] and
+    (__ \ "descCy").format[String]
   )(SicCode.apply, unlift(SicCode.unapply))
 }
 

--- a/app/services/JourneyService.scala
+++ b/app/services/JourneyService.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 class JourneyService @Inject()(journeyDataRepository: JourneyDataRepository,
                                val sicSearchService: SicSearchService) {
 
-  def initialiseJourney(journeyData: JourneyData)(implicit hc: HeaderCarrier): Future[JsValue] = {
+  def initialiseJourney(journeyData: JourneyData, lang: String)(implicit hc: HeaderCarrier): Future[JsValue] = {
     for {
       res <- journeyDataRepository.upsertJourney(journeyData) map { _ =>
         Json.obj(
@@ -38,7 +38,7 @@ class JourneyService @Inject()(journeyDataRepository: JourneyDataRepository,
           "fetchResultsUri" -> s"/internal/${journeyData.identifiers.journeyId}/fetch-results"
         )
       }
-      sicCodes = journeyData.journeySetupDetails.sicCodes map (SicCode(_, ""))
+      sicCodes = journeyData.journeySetupDetails.sicCodes map (SicCode(_, "", ""))
       _ <- sicSearchService.lookupSicCodes(journeyData, sicCodes.toList)
     } yield res
   }

--- a/app/views/pages/chooseActivity.scala.html
+++ b/app/views/pages/chooseActivity.scala.html
@@ -81,7 +81,7 @@
                             idPrefix = "code",
                             legend = messages("page.icl.chooseActivity.title"),
                             items = searchResults.results.map(sicCode => CheckboxItem(
-                                content = Text(sicCode.description),
+                                content = Text(sicCode.getDescription),
                                 value = sicCode.sicCode
                             )),
                             legendAsHeading = false,

--- a/app/views/pages/confirmation.scala.html
+++ b/app/views/pages/confirmation.scala.html
@@ -97,7 +97,7 @@
 
 @tableContent(sicCodeChoice: SicCodeChoice) = {
     @p() {
-        @sicCodeChoice.code - @sicCodeChoice.desc
+        @sicCodeChoice.code - @sicCodeChoice.getDescription
     }
-    @includesHelper(sicCodeChoice.indexes)
+    @includesHelper(sicCodeChoice.getIndexes)
 }

--- a/app/views/pages/removeActivityConfirmation.scala.html
+++ b/app/views/pages/removeActivityConfirmation.scala.html
@@ -29,13 +29,13 @@
 
 @(journeyId: String, removeSicCodeForm: Form[String], sicCodeChoice: SicCodeChoice)(implicit lang: play.api.i18n.Lang, request: Request[_], messages: Messages, appConfig: AppConfig)
 
-@layout(pageTitle = Some(title(removeSicCodeForm, messages("page.icl.confirmremoval.title", sicCodeChoice.desc))), backLink = true) {
+@layout(pageTitle = Some(title(removeSicCodeForm, messages("page.icl.confirmremoval.title", sicCodeChoice.getDescription))), backLink = true) {
 
     @errorSummary(removeSicCodeForm.errors)
 
-    @h1(messages("page.icl.confirmremoval.heading", sicCodeChoice.desc))
+    @h1(messages("page.icl.confirmremoval.heading", sicCodeChoice.getDescription))
 
-    @includesHelper(sicCodeChoice.indexes)
+    @includesHelper(sicCodeChoice.getIndexes)
 
     @formWithCSRF(action = controllers.routes.RemoveSicCodeController.submit(journeyId, sicCodeChoice.code)) {
         @yesNoRadio(
@@ -43,7 +43,7 @@
             fieldName = "removeCode",
             yesValue = "yes",
             noValue = "no",
-            headingKey = messages("page.icl.confirmremoval.title", sicCodeChoice.desc),
+            headingKey = messages("page.icl.confirmremoval.title", sicCodeChoice.getDescription),
             isPageHeading = false,
             classes = "govuk-visually-hidden",
             inline = true

--- a/it/helpers/ICLStub.scala
+++ b/it/helpers/ICLStub.scala
@@ -2,18 +2,19 @@
 package helpers
 
 import com.github.tomakehurst.wiremock.client.WireMock._
-import play.api.libs.json.Json
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.libs.json.{JsObject, Json}
 
 trait ICLStub {
-  val sicCodeLookupResult = Json.obj(
+  val sicCodeLookupResult: JsObject = Json.obj(
     "numFound" -> 36,
     "nonFilteredFound" -> 36,
     "results" -> Json.arr(
-      Json.obj("code" -> "01410003", "desc" -> "Dairy farming"),
-      Json.obj("code" -> "01420003", "desc" -> "Cattle farming"),
-      Json.obj("code" -> "03220009", "desc" -> "Frog farming"),
-      Json.obj("code" -> "01490008", "desc" -> "Fur farming"),
-      Json.obj("code" -> "01490026", "desc" -> "Snail farming")
+      Json.obj("code" -> "01410003", "desc" -> "Dairy farming", "descCy" -> "Dairy farming"),
+      Json.obj("code" -> "01420003", "desc" -> "Cattle farming", "descCy" -> "Cattle farming"),
+      Json.obj("code" -> "03220009", "desc" -> "Cattle farming", "descCy" -> "Cattle farming"),
+      Json.obj("code" -> "01490008", "desc" -> "Fur farming", "descCy" -> "Fur farming"),
+      Json.obj("code" -> "01490026", "desc" -> "Snail farming", "descCy" -> "Snail farming")
     ),
     "sectors" -> Json.arr(
       Json.obj("code" -> "A", "name" -> "Agriculture, Forestry And Fishing", "nameCy" -> "Cy business sector", "count" -> 19),
@@ -22,7 +23,7 @@ trait ICLStub {
       Json.obj("code" -> "N", "name" -> "Administrative And Support Service Activities", "nameCy" -> "Cy business sector", "count" -> 1)
     )
   )
-  def stubGETICLSearchResults = {
+  def stubGETICLSearchResults: StubMapping = {
   stubFor(get(urlMatching("/industry-classification-lookup/search?.*"))
     .willReturn(
       aResponse()

--- a/it/internal/ApiControllerISpec.scala
+++ b/it/internal/ApiControllerISpec.scala
@@ -140,9 +140,9 @@ class ApiControllerISpec extends ClientSpec {
         )
 
         setupUnauthorised()
-        val responseBody = Json.toJson(List(SicCode("12345", "desc one"), SicCode("67890", "desc 2"))).toString()
+        val responseBody = Json.toJson(List(SicCode("12345", "desc one", "desc one"), SicCode("67890", "desc 2", "desc 2"))).toString()
 
-        stubGet("/industry-classification-lookup/lookup/67890,12345", 200, Some(responseBody))
+        stubGet(s"/industry-classification-lookup/lookup/67890,12345", 200, Some(responseBody))
         await(journeyRepo.count) mustBe 0
         await(sicStoreRepo.count) mustBe 0
 
@@ -237,7 +237,7 @@ class ApiControllerISpec extends ClientSpec {
         val sessionIdValue = "test-session-id"
         val sessionId: String = getSessionCookie(sessionID = "test-session-id")
 
-        val sicCodeChoices = List(SicCodeChoice(SicCode("12345", "test description"), Nil))
+        val sicCodeChoices = List(SicCodeChoice(SicCode("12345", "test description", "test description"), Nil, Nil))
         val sicStore: SicStore = SicStore(journeyId, None, Some(sicCodeChoices))
         insertSicStore(sicStore)
 

--- a/test/controllers/ChooseActivityControllerSpec.scala
+++ b/test/controllers/ChooseActivityControllerSpec.scala
@@ -26,7 +26,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Result}
+import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Cookie, Result}
 import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core.AuthConnector
 import views.html.pages.chooseActivity
@@ -55,9 +55,10 @@ class ChooseActivityControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite
       override lazy val loginURL = "/test/login"
     }
 
-    val requestWithSession: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSessionId(sessionId)
+    val requestWithSession: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSessionId(sessionId).withCookies(Cookie("PLAY_LANG", "en"))
   }
 
+  val lang = "en"
   val journeyId = "testJourneyId"
   val sessionId = "session-12345"
   val identifiers = Identifiers(journeyId, sessionId)
@@ -66,8 +67,8 @@ class ChooseActivityControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite
 
   val SECTOR_A = "A"
   val query = "testQuery"
-  val sicCode = SicCode("12345", "Test Description")
-  val sicCode2 = SicCode("12345", "Test Description2")
+  val sicCode = SicCode("12345", "Test Description", "Test Description")
+  val sicCode2 = SicCode("12345", "Test Description2", "Test Description2")
 
   val searchResults = SearchResults(query, 1, List(sicCode), List(Sector(SECTOR_A, "Fake Sector", "Cy business sector", 1)))
   val noSearchResults = SearchResults(query, 0, List(), List())
@@ -168,7 +169,7 @@ class ChooseActivityControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite
   "Submit a search" should {
     "return a 303 with the search results page" in new Setup {
 
-      when(mockSicSearchService.search(any(), eqTo(query), any())(any(), any()))
+      when(mockSicSearchService.search(any(), eqTo(query), any(), eqTo(lang))(any(), any()))
         .thenReturn(Future.successful(multipleSearchResults.numFound))
 
       when(mockJourneyService.getJourney(ArgumentMatchers.any())) thenReturn Future.successful(journeyData)
@@ -186,7 +187,7 @@ class ChooseActivityControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite
 
     "return a 303 with the choices list page for an authorised user when the search returns only 1 result" in new Setup {
 
-      when(mockSicSearchService.search(any(), eqTo(query), any())(any(), any()))
+      when(mockSicSearchService.search(any(), eqTo(query), any(), eqTo(lang))(any(), any()))
         .thenReturn(Future.successful(searchResults.numFound))
 
       when(mockJourneyService.getJourney(ArgumentMatchers.any())) thenReturn Future.successful(journeyData)
@@ -237,7 +238,7 @@ class ChooseActivityControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite
       when(mockJourneyService.getJourney(ArgumentMatchers.any())) thenReturn Future.successful(journeyData)
 
       val request: FakeRequest[AnyContentAsFormUrlEncoded] = requestWithSession.withFormUrlEncodedBody(
-        "code[0]" -> "12345"
+        "code[0]" -> "12345-test description-test description"
       )
 
       requestWithAuthorisedUser(controller.submit(journeyId), request) {
@@ -270,7 +271,7 @@ class ChooseActivityControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite
       when(mockSicSearchService.retrieveSearchResults(eqTo(journeyId))(any()))
         .thenReturn(Future.successful(Some(searchResults)))
 
-      when(mockSicSearchService.search(any(), eqTo(query), any())(any(), any()))
+      when(mockSicSearchService.search(any(), eqTo(query), any(), eqTo(lang))(any(), any()))
         .thenReturn(Future.successful(1))
 
       when(mockJourneyService.getJourney(ArgumentMatchers.any())) thenReturn Future.successful(journeyData)
@@ -286,7 +287,7 @@ class ChooseActivityControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite
       when(mockSicSearchService.retrieveSearchResults(eqTo(journeyId))(any()))
         .thenReturn(Future.successful(Some(noSearchResults)))
 
-      when(mockSicSearchService.search(any(), eqTo(query), any())(any(), any()))
+      when(mockSicSearchService.search(any(), eqTo(query), any(), eqTo(lang))(any(), any()))
         .thenReturn(Future.successful(0))
 
       when(mockJourneyService.getJourney(ArgumentMatchers.any())) thenReturn Future.successful(journeyData)
@@ -304,7 +305,7 @@ class ChooseActivityControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite
       when(mockSicSearchService.retrieveSearchResults(eqTo(journeyId))(any()))
         .thenReturn(Future.successful(Some(searchResults)))
 
-      when(mockSicSearchService.search(any(), eqTo(query), any())(any(), any()))
+      when(mockSicSearchService.search(any(), eqTo(query), any(), eqTo(lang))(any(), any()))
         .thenReturn(Future.successful(1))
 
       when(mockJourneyService.getJourney(ArgumentMatchers.any())) thenReturn Future.successful(journeyData)

--- a/test/controllers/ConfirmationControllerSpec.scala
+++ b/test/controllers/ConfirmationControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package controllers
 
-import akka.stream.scaladsl.Sink
 import featureswitch.core.config.{FeatureSwitching, WelshLanguage}
 import helpers.UnitTestSpec
 import helpers.mocks.{MockAppConfig, MockMessages}
@@ -28,7 +27,6 @@ import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import play.api.mvc._
 import play.api.test.{FakeRequest, Helpers}
-import play.api.test.Helpers.await
 import views.html.pages.confirmation
 
 import java.time.LocalDateTime
@@ -72,8 +70,8 @@ class ConfirmationControllerSpec extends UnitTestSpec with MockAppConfig with Mo
 
   val sicCodeCode = "12345"
   val sicCodeDescription = "some description"
-  val sicCode = SicCode(sicCodeCode, sicCodeDescription)
-  val sicCodeChoice = SicCodeChoice(sicCode, List("fake item"))
+  val sicCode = SicCode(sicCodeCode, sicCodeDescription, sicCodeDescription)
+  val sicCodeChoice = SicCodeChoice(sicCode, List("fake item"), List("fake item"))
   val searchResults = SearchResults("testQuery", 1, List(sicCode), List(Sector("A", "Fake Sector", "Cy business sector", 1)))
 
   "show" should {

--- a/test/controllers/RemoveSicCodeControllerSpec.scala
+++ b/test/controllers/RemoveSicCodeControllerSpec.scala
@@ -62,8 +62,8 @@ class RemoveSicCodeControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite 
 
   val sicCodeCode = "12345"
   val sicCodeDescription = "some description"
-  val sicCode = SicCode(sicCodeCode, sicCodeDescription)
-  val sicCodeChoice = SicCodeChoice(sicCode, List("fake item"))
+  val sicCode = SicCode(sicCodeCode, sicCodeDescription, sicCodeDescription)
+  val sicCodeChoice = SicCodeChoice(sicCode, List("fake item"), List("fake item"))
   val searchResults = SearchResults("testQuery", 1, List(sicCode), List(Sector("A", "Fake Sector", "Cy business sector", 1)))
 
   "show" should {

--- a/test/controllers/internal/ApiControllerSpec.scala
+++ b/test/controllers/internal/ApiControllerSpec.scala
@@ -18,9 +18,9 @@ package controllers.internal
 
 import helpers.UnitTestSpec
 import helpers.mocks.{MockAppConfig, MockMessages}
-import models.setup.{Identifiers, JourneyData, JourneySetup}
 import models.{SicCode, SicCodeChoice}
-import org.mockito.ArgumentMatchers.any
+import models.setup.{Identifiers, JourneyData, JourneySetup}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{AnyContentAsEmpty, Result}
@@ -47,7 +47,7 @@ class ApiControllerSpec extends UnitTestSpec with MockMessages with MockAppConfi
   }
 
   "journeyInitialisation" should {
-
+    val lang = "en"
     val validRequestedJson: JsValue = Json.parse(
       """{
         | "redirectUrl": "test/url",
@@ -80,7 +80,7 @@ class ApiControllerSpec extends UnitTestSpec with MockMessages with MockAppConfi
       )
 
       "journey is initialised with custom messages" in new Setup {
-        when(mockJourneyService.initialiseJourney(any())(any())) thenReturn Future.successful(expectedJsonResponse)
+        when(mockJourneyService.initialiseJourney(any(), eqTo(lang))(any())) thenReturn Future.successful(expectedJsonResponse)
 
         val result: Future[Result] = controller.journeyInitialisation()(requestWithSessionId)
 
@@ -93,7 +93,7 @@ class ApiControllerSpec extends UnitTestSpec with MockMessages with MockAppConfi
           .withSessionId("test-session-id")
           .withBody(validRequestedJsonWithoutCustomMessages)
 
-        when(mockJourneyService.initialiseJourney(any())(any())) thenReturn Future.successful(expectedJsonResponse)
+        when(mockJourneyService.initialiseJourney(any(), eqTo(lang))(any())) thenReturn Future.successful(expectedJsonResponse)
 
         val result: Future[Result] = controller.journeyInitialisation()(fakeRequest)
         status(result) mustBe OK
@@ -142,8 +142,8 @@ class ApiControllerSpec extends UnitTestSpec with MockMessages with MockAppConfi
     "return 200 with json" when {
       "the journey exists and there have been sic codes selected" in new Setup {
 
-        val sicCode = SicCode("12345", "test description")
-        val sicCodeChoice = SicCodeChoice(sicCode, List("123", "456", "789"))
+        val sicCode = SicCode("12345", "test description", "test description")
+        val sicCodeChoice = SicCodeChoice(sicCode, List("123", "456", "789"), List("123", "456", "789"))
         val sicCodeChoices = List(sicCodeChoice)
 
         val sicCodeChoicesJson: JsValue = Json.parse(
@@ -153,7 +153,13 @@ class ApiControllerSpec extends UnitTestSpec with MockMessages with MockAppConfi
             |     {
             |       "code":"12345",
             |       "desc":"test description",
+            |       "descCy":"test description",
             |       "indexes":[
+            |         "123",
+            |         "456",
+            |         "789"
+            |       ],
+            |       "indexesCy":[
             |         "123",
             |         "456",
             |         "789"

--- a/test/controllers/test/TestSetupControllerSpec.scala
+++ b/test/controllers/test/TestSetupControllerSpec.scala
@@ -20,7 +20,7 @@ import helpers.UnitTestSpec
 import helpers.mocks.{MockAppConfig, MockMessages}
 import models._
 import models.setup.{Identifiers, JourneyData, JourneySetup}
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.Json
@@ -54,6 +54,7 @@ class TestSetupControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite with
     val requestWithSessionId: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSessionId(sessionId)
   }
 
+  val lang = "en"
   val journeyId = "testJourneyId"
   val sessionId = "session-12345"
   val identifiers = Identifiers(journeyId, sessionId)
@@ -65,7 +66,7 @@ class TestSetupControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite with
 
   val sicStore = SicStore(
     sessionId,
-    Some(SearchResults("test-query", 1, List(SicCode("19283", "Search Sic Code Result Description")), List()))
+    Some(SearchResults("test-query", 1, List(SicCode("19283", "Search Sic Code Result Description", "Search Sic Code Result Description")), List()))
   )
 
   "show" should {
@@ -123,7 +124,7 @@ class TestSetupControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite with
 
   "testSetup" must {
     "redirect to the test setup show page" in new Setup {
-      when(mockJourneyService.initialiseJourney(any())(any())) thenReturn Future.successful(Json.parse("""{}"""))
+      when(mockJourneyService.initialiseJourney(any(), eqTo(lang))(any())) thenReturn Future.successful(Json.parse("""{}"""))
 
       AuthHelpers.showWithAuthorisedUser(controller.testSetup, requestWithSessionId) { result =>
         status(result) mustBe SEE_OTHER
@@ -141,7 +142,7 @@ class TestSetupControllerSpec extends UnitTestSpec with GuiceOneAppPerSuite with
   "endOfJourney" must {
     "return Ok when a journey exists and have a session" in new Setup {
 
-      val sicCodeChoices = Some(List(SicCodeChoice(SicCode("12345", "test description"))))
+      val sicCodeChoices = Some(List(SicCodeChoice(SicCode("12345", "test description", "test description"))))
 
       when(mockJourneyService.getJourney(any())) thenReturn Future.successful(journeyData)
 

--- a/test/forms/ChooseMultipleActivityFormSpec.scala
+++ b/test/forms/ChooseMultipleActivityFormSpec.scala
@@ -17,10 +17,10 @@
 package forms
 
 import forms.chooseactivity.ChooseMultipleActivitiesForm
-import models.SicCode
+import models.{SearchResults, SicCode}
 import org.scalatestplus.play.PlaySpec
 import play.api.data.FormBinding.Implicits.formBinding
-import play.api.data.{FormBinding, FormError}
+import play.api.data.FormError
 import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test.FakeRequest
 
@@ -37,45 +37,46 @@ class ChooseMultipleActivityFormSpec extends PlaySpec {
   implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest().withFormUrlEncodedBody(inputMap.toSeq: _*)
 
   val inputMap2: Map[String, String] = Map(
-    "code[0]" -> "testCode0",
-    "code[1]" -> "testCode1",
+    "code[0]" -> "testCode0-testDescription0",
+    "code[1]" -> "testCode1-testDescription1",
     "code[2]" -> "",
-    "code[3]" -> "testCode3",
-    "code[4]" -> "testCode4"
+    "code[3]" -> "testCode3-testDescription3",
+    "code[4]" -> "testCode4-testDescription4"
   )
 
-  val expectedList = List("testCode0", "testCode1", "testCode2", "testCode3", "testCode4")
-  val expectedSicCodeList = List(SicCode("testCode0", "testDescription0"),
-    SicCode("testCode1", "testDescription1"),
-    SicCode("testCode2", "testDescription2"),
-    SicCode("testCode3", "testDescription3"),
-    SicCode("testCode4", "testDescription4"))
+  val expectedSicCodeList = List(SicCode("testCode0", "testDescription0", "testDescription0"),
+    SicCode("testCode1", "testDescription1", "testDescription1"),
+    SicCode("testCode2", "testDescription2", "testDescription2"),
+    SicCode("testCode3", "testDescription3", "testDescription3"),
+    SicCode("testCode4", "testDescription4", "testDescription4"))
+
+  val searchResults = SearchResults("test-query", 1, expectedSicCodeList, List())
 
   "SicSearchMultipleForm" should {
     "bind successfully" when {
       "binding from a request" in {
-        ChooseMultipleActivitiesForm.form.bindFromRequest().get mustBe expectedSicCodeList
+        ChooseMultipleActivitiesForm.form(Some(searchResults)).bindFromRequest().get mustBe expectedSicCodeList
       }
 
       "binding from a map and transform data" in {
-        ChooseMultipleActivitiesForm.form.bind(inputMap).get mustBe expectedSicCodeList
+        ChooseMultipleActivitiesForm.form(Some(searchResults)).bind(inputMap).get mustBe expectedSicCodeList
       }
 
       "binding from a map" in {
-        ChooseMultipleActivitiesForm.form.bind(inputMap).get mustBe expectedSicCodeList
+        ChooseMultipleActivitiesForm.form(Some(searchResults)).bind(inputMap).get mustBe expectedSicCodeList
       }
 
       "binding from a map with gaps" in {
-        ChooseMultipleActivitiesForm.form.bind(inputMap2).get mustBe List(
-          SicCode("testCode0", "testCode0"),
-          SicCode("testCode1", "testCode1"),
-          SicCode("testCode3", "testCode3"),
-          SicCode("testCode4", "testCode4"))
+        ChooseMultipleActivitiesForm.form(Some(searchResults)).bind(inputMap2).get mustBe List(
+          SicCode("testCode0", "testDescription0", "testDescription0"),
+          SicCode("testCode1", "testDescription1", "testDescription1"),
+          SicCode("testCode3", "testDescription3", "testDescription3"),
+          SicCode("testCode4", "testDescription4", "testDescription4"))
       }
     }
 
     "return an empty list when unbinding from sic code" in {
-      ChooseMultipleActivitiesForm.form.mapping.unbind(expectedSicCodeList) mustBe Map()
+      ChooseMultipleActivitiesForm.form(None).mapping.unbind(expectedSicCodeList) mustBe Map()
     }
 
     "bind unsuccessfully" when {
@@ -84,11 +85,11 @@ class ChooseMultipleActivityFormSpec extends PlaySpec {
       )
 
       "nothing is the request" in {
-        ChooseMultipleActivitiesForm.form.bindFromRequest()(FakeRequest(), formBinding).errors mustBe emptyErrors
+        ChooseMultipleActivitiesForm.form(None).bindFromRequest()(FakeRequest(), formBinding).errors mustBe emptyErrors
       }
 
       "the map is empty" in {
-        ChooseMultipleActivitiesForm.form.bind(Map.empty[String, String]).errors mustBe emptyErrors
+        ChooseMultipleActivitiesForm.form(None).bind(Map.empty[String, String]).errors mustBe emptyErrors
       }
     }
   }

--- a/test/models/SicStoreSpec.scala
+++ b/test/models/SicStoreSpec.scala
@@ -35,17 +35,17 @@ class SicStoreSpec extends UnitTestSpec {
        |    "query":"$query",
        |    "numFound":1,
        |    "results":[
-       |      {"code" : "19283", "desc" : "Search Sic Code Result Description"}
+       |      {"code" : "19283", "desc" : "Search Sic Code Result Description", "descCy" : "Search Sic Code Result Description"}
        |    ],
        |    "sectors":[
        |      {"code" : "A", "name" : "Clearly fake business sector", "nameCy": "Cy business sector", "count": 22}
        |    ]
        |  },
        |  "choices" : [
-       |    {"code" : "57384", "desc" : "Sic Code Test Description 1", "indexes": ["someIndex 1"]},
-       |    {"code" : "11920", "desc" : "Sic Code Test Description 2", "indexes": ["someIndex 2"]},
-       |    {"code" : "12994", "desc" : "Sic Code Test Description 3", "indexes": ["someIndex 3"]},
-       |    {"code" : "39387", "desc" : "Sic Code Test Description 4", "indexes": []}
+       |    {"code" : "57384", "desc" : "Sic Code Test Description 1", "descCy" : "Sic Code Test Description 1", "indexes": ["someIndex 1"], "indexesCy": ["someIndex 1"]},
+       |    {"code" : "11920", "desc" : "Sic Code Test Description 2", "descCy" : "Sic Code Test Description 2", "indexes": ["someIndex 2"], "indexesCy": ["someIndex 2"]},
+       |    {"code" : "12994", "desc" : "Sic Code Test Description 3", "descCy" : "Sic Code Test Description 3", "indexes": ["someIndex 3"], "indexesCy": ["someIndex 3"]},
+       |    {"code" : "39387", "desc" : "Sic Code Test Description 4", "descCy" : "Sic Code Test Description 4", "indexes": [], "indexesCy": []}
        |  ],
        |  "lastUpdated" : $now
        |}
@@ -60,7 +60,7 @@ class SicStoreSpec extends UnitTestSpec {
        |     "query":"$query",
        |     "numFound":1,
        |     "results":[
-       |       {"code" : "19283", "desc" : "Search Sic Code Result Description"}
+       |       {"code" : "19283", "desc" : "Search Sic Code Result Description", "descCy" : "Search Sic Code Result Description"}
        |     ],
        |     "sectors":[
        |       {"code" : "A", "name" : "Clearly fake business sector", "nameCy": "Cy business sector", "count": 22}
@@ -76,14 +76,14 @@ class SicStoreSpec extends UnitTestSpec {
     Some(SearchResults(
       query,
       1,
-      List(SicCode("19283", "Search Sic Code Result Description")),
+      List(SicCode("19283", "Search Sic Code Result Description", "Search Sic Code Result Description")),
       List(Sector("A", "Clearly fake business sector", "Cy business sector", 22))
     )),
     Some(List(
-      SicCodeChoice(SicCode("57384", "Sic Code Test Description 1"), List("someIndex 1")),
-      SicCodeChoice(SicCode("11920", "Sic Code Test Description 2"), List("someIndex 2")),
-      SicCodeChoice(SicCode("12994", "Sic Code Test Description 3"), List("someIndex 3")),
-      SicCodeChoice(SicCode("39387", "Sic Code Test Description 4"), List())
+      SicCodeChoice(SicCode("57384", "Sic Code Test Description 1", "Sic Code Test Description 1"), List("someIndex 1"), List("someIndex 1")),
+      SicCodeChoice(SicCode("11920", "Sic Code Test Description 2", "Sic Code Test Description 2"), List("someIndex 2"), List("someIndex 2")),
+      SicCodeChoice(SicCode("12994", "Sic Code Test Description 3", "Sic Code Test Description 3"), List("someIndex 3"), List("someIndex 3")),
+      SicCodeChoice(SicCode("39387", "Sic Code Test Description 4", "Sic Code Test Description 4"), List(), List())
     )),
     dateTime
   )
@@ -93,7 +93,7 @@ class SicStoreSpec extends UnitTestSpec {
     Some(SearchResults(
       query,
       1,
-      List(SicCode("19283", "Search Sic Code Result Description")),
+      List(SicCode("19283", "Search Sic Code Result Description", "Search Sic Code Result Description")),
       List(Sector("A", "Clearly fake business sector", "Cy business sector", 22))
     )),
     None,

--- a/test/services/JourneySetupServiceSpec.scala
+++ b/test/services/JourneySetupServiceSpec.scala
@@ -21,7 +21,7 @@ import java.time.LocalDateTime
 import helpers.UnitTestSpec
 import helpers.mocks.MockJourneyDataRepo
 import models.setup.{Identifiers, JourneyData, JourneySetup}
-import org.mockito.ArgumentMatchers._
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import play.api.libs.json.Json
 
@@ -38,6 +38,7 @@ class JourneySetupServiceSpec extends UnitTestSpec with MockJourneyDataRepo {
     )
   }
 
+  val lang = "en"
   val identifier = Identifiers(
     journeyId = "testJourneyId",
     sessionId = "testSessionId"
@@ -57,7 +58,7 @@ class JourneySetupServiceSpec extends UnitTestSpec with MockJourneyDataRepo {
       mockInitialiseJourney(testJourneyData)
       when(mockSicSearchService.lookupSicCodes(any(), any())(any(), any())).thenReturn(Future.successful(0))
 
-      assertAndAwait(testService.initialiseJourney(testJourneyData)) {
+      assertAndAwait(testService.initialiseJourney(testJourneyData, lang)) {
         _ mustBe Json.obj(
           "journeyStartUri" -> s"/sic-search/testJourneyId/start-journey",
           "fetchResultsUri" -> s"/internal/testJourneyId/fetch-results"

--- a/test/views/pages/ChooseActivityViewSpec.scala
+++ b/test/views/pages/ChooseActivityViewSpec.scala
@@ -36,7 +36,7 @@ class ChooseActivityViewSpec extends UnitTestSpec with GuiceOneAppPerSuite with 
 
   val query = "test query"
 
-  val testSicCode = SicCode("12345", "Testing")
+  val testSicCode = SicCode("12345", "Testing", "Testing")
 
   val searchResults = SearchResults(query, 1, List(testSicCode), List(Sector("A", "Fake Sector", "Cy business sector", 1)))
 
@@ -47,7 +47,7 @@ class ChooseActivityViewSpec extends UnitTestSpec with GuiceOneAppPerSuite with 
   val back = "Back"
 
   "The choose activity screen" should {
-    lazy val view = app.injector.instanceOf[chooseActivity].apply(journeyId, SicSearchForm.form.fill(SicSearch(query)), ChooseMultipleActivitiesForm.form, Some(searchResults))
+    lazy val view = app.injector.instanceOf[chooseActivity].apply(journeyId, SicSearchForm.form.fill(SicSearch(query)), ChooseMultipleActivitiesForm.form(None), Some(searchResults))
     lazy val document = Jsoup.parse(view.body)
 
     "have the correct title" in {
@@ -59,7 +59,7 @@ class ChooseActivityViewSpec extends UnitTestSpec with GuiceOneAppPerSuite with 
         app.injector.instanceOf[chooseActivity].apply(
           journeyId,
           SicSearchForm.form.fill(SicSearch(query)),
-          ChooseMultipleActivitiesForm.form,
+          ChooseMultipleActivitiesForm.form(None),
           Some(searchResults.copy(numFound = 0))
         )
       Jsoup.parse(viewWithNoResult.body).getElementsByTag("title").first().text mustBe s"0 results - $pageTitle"

--- a/test/views/pages/ConfirmationViewSpec.scala
+++ b/test/views/pages/ConfirmationViewSpec.scala
@@ -32,8 +32,8 @@ class ConfirmationViewSpec extends UnitTestSpec with GuiceOneAppPerSuite with Mo
   override def messagesApi: MessagesApi = mockMessagesApi
 
   val sicCodeChoices = List(
-    SicCodeChoice("12345", "my fake description", List("this is the index")),
-    SicCodeChoice("67892", "my fake second description", List("this is index", "with another one"))
+    SicCodeChoice("12345", "my fake description", "my fake description", List("this is the index")),
+    SicCodeChoice("67892", "my fake second description", "my fake second description", List("this is index", "with another one"))
   )
 
   val pageHeading = "MyPageHeading"


### PR DESCRIPTION
[SAR-10768](https://jira.tools.tax.service.gov.uk/browse/SAR-10768)

**New feature**

Add support for welsh language search, pass language cookie (defaulted to `en`) to ICL backend. 

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
